### PR TITLE
Support multiple Snyk org IDs

### DIFF
--- a/templates/snyk-ecr.template.yaml
+++ b/templates/snyk-ecr.template.yaml
@@ -36,9 +36,8 @@ Metadata:
 Parameters:
   SnykExternalId:
     Description: Locate the organization ID by logging in to https://app.snyk.io and navigating to Settings.
-    Type: String
-    AllowedPattern: '[a-z0-9-]{36}'
-    MinLength: 1
+    Type: CommaDelimitedList
+    Default: "abcd1234-abcd-1234-abcd-1234abcd1234, abcd1234-abcd-1234-abcd-1234abcd1234"
   SnykAWSAccountNumber:
     Description: "Snyk's AWS Account ID which assumes a role in your account. Please see the deployment guide 'Technical requirements | Snyk Account Access' for this Account ID"
     Type: String

--- a/templates/snyk-full.template.yaml
+++ b/templates/snyk-full.template.yaml
@@ -49,9 +49,8 @@ Metadata:
 Parameters:
   SnykExternalId:
     Description: Locate the organization ID by logging in to https://app.snyk.io and navigating to Settings.
-    Type: String
-    AllowedPattern: '[a-z0-9-]{36}'
-    MinLength: 1
+    Type: CommaDelimitedList
+    Default: "abcd1234-abcd-1234-abcd-1234abcd1234, abcd1234-abcd-1234-abcd-1234abcd1234"
   SnykAWSAccountNumber:
     Description: "Snyk's AWS Account ID which assumes a role in your account. Please see the deployment guide 'Technical requirements | Snyk Account Access' for this Account ID"
     Type: String
@@ -87,7 +86,7 @@ Resources:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       Parameters:
-        SnykExternalId: !Ref 'SnykExternalId'
+        SnykExternalId: !Join [",", !Ref 'SnykExternalId']
         SnykAWSAccountNumber: !Ref 'SnykAWSAccountNumber'
       TemplateURL: !Sub
         - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/snyk-ecr.template.yaml'
@@ -103,7 +102,7 @@ Resources:
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       Parameters:
-        SnykExternalId: !Ref 'SnykExternalId'
+        SnykExternalId: !Join [",", !Ref 'SnykExternalId']
         SnykAWSAccountNumber: !Ref 'SnykAWSAccountNumber'
       TemplateURL: !Sub
         - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/snyk-lambda.template.yaml'

--- a/templates/snyk-lambda.template.yaml
+++ b/templates/snyk-lambda.template.yaml
@@ -33,9 +33,8 @@ Metadata:
 Parameters:
   SnykExternalId:
     Description: Locate the organization ID by logging in to https://app.snyk.io and navigating to Settings.
-    Type: String
-    AllowedPattern: '[a-z0-9-]{36}'
-    MinLength: 1
+    Type: CommaDelimitedList
+    Default: "abcd1234-abcd-1234-abcd-1234abcd1234, abcd1234-abcd-1234-abcd-1234abcd1234"
   SnykAWSAccountNumber:
     Description: "Snyk's AWS Account ID which assumes a role in your account. Please see the deployment guide 'Technical requirements | Snyk Account Access' for this Account ID"
     Type: String


### PR DESCRIPTION
*Description of changes:*
The IAM role(s) created by this quick start can integrate ECR & Lambda with multiple Snyk organizations:
<img width="414" alt="image" src="https://user-images.githubusercontent.com/11740869/167197855-5d5c7882-c68f-4405-8caa-f2f79df295bf.png">

Amended the `SnykExternalId` parameter type to support this behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
